### PR TITLE
fix: Enhance changelog script to support unreleased changes

### DIFF
--- a/release.config.ts
+++ b/release.config.ts
@@ -23,7 +23,10 @@ const config: Options = {
         // 在 prepare 阶段执行脚本，此时 nextRelease 已确定
         // nextRelease 没有 date 字段，脚本会从 notes 中提取日期或使用当前日期
         // 脚本会自动提交并推送到 Docs 子仓库
-        prepareCmd: 'TS_NODE_PROJECT=tsconfig.release.json NODE_OPTIONS="--loader ts-node/esm" node scripts/write-changelog-to-docs.ts "${nextRelease.version}" "${nextRelease.notes}"'
+        prepareCmd: 'TS_NODE_PROJECT=tsconfig.release.json NODE_OPTIONS="--loader ts-node/esm" node scripts/write-changelog-to-docs.ts "${nextRelease.version}" "${nextRelease.notes}"',
+        // 在 success 阶段，如果没有发布版本（没有 nextRelease），记录未发布的提交
+        // 使用 shell 脚本检查是否有 nextRelease.version 环境变量
+        successCmd: 'if [ -z "${nextRelease.version}" ]; then TS_NODE_PROJECT=tsconfig.release.json NODE_OPTIONS="--loader ts-node/esm" node scripts/write-changelog-to-docs.ts --unreleased; fi'
       }
     ],
     [


### PR DESCRIPTION
- Updated `write-changelog-to-docs.ts` to handle an `--unreleased` flag, allowing extraction of commits since the last release.
- Modified `release.config.ts` to include a success command for logging unreleased commits.
- Improved error handling and output messages for better user experience.